### PR TITLE
chore: set distraction effect inside interval

### DIFF
--- a/src/simulators/distractions.ts
+++ b/src/simulators/distractions.ts
@@ -4,139 +4,159 @@ export const activeDistractions = () => {
   scriptImportedFromExternalRepository();
 };
 
-export const removeDistractions = () => {
-  clearInterval(distractionIntervale);
+const timeouts: NodeJS.Timeout[] = [];
+
+// used to save and clear timeouts
+export const TIMEOUTS = {
+  timeouts,
+  setTimeout: function (fn: () => void, delay: number) {
+    const id = setTimeout(fn, delay);
+    this.timeouts.push(id);
+  },
+  clearAllTimeouts: function () {
+    while (this.timeouts.length) {
+      clearTimeout(this.timeouts.pop()!);
+    }
+  },
 };
 
+// ==UserScript==
+// @name         Distractions
+// @namespace    https://github.com/alphagov/accessibility-personas
+// @version      1.0.0
+// @license      ISC
+// @author       Metamatrix AB [https://github.com/Metamatrix/web-disability-simulator] and Crown Copyright (Government Digital Service)
+// @description  Clutter the screen with various distractions to simulate finding it hard to concentrate; has to be used together with distractions.user.css to work
+// @homepageURL  https://alphagov.github.io/accessibility-personas/
+// @include      *
+// @grant        none
+// @nocompat     Chrome
+// ==/UserScript==
+
+//dom elements to apply animations on
+const h2 = "h2";
+const p = "p";
+const img = "img";
+
+//dom elements to be created
+const imgEl_0 = ".wds-img-element";
+const textEl_0 = ".wds-text-element-0";
+const textEl_1 = ".wds-text-element-1";
+const textEl_2 = ".wds-text-element-2";
+const textEl_3 = ".wds-text-element-3";
+const textEl_4 = ".wds-text-element-4";
+
+//classes for css animations
+const paragraphAnimation = "wds-paragraph-animation";
+const headingAnimation = "wds-heading-animation";
+const imgAnimation_0 = "wds-img-animation-0";
+const imgAnimation_1 = "wds-img-animation-1";
+const textAnimation_0 = "wds-text-animation-0";
+const textAnimation_1 = "wds-text-animation-1";
+const textAnimation_2 = "wds-text-animation-2";
+const textAnimation_3 = "wds-text-animation-3";
+const textAnimation_4 = "wds-text-animation-4";
+
+function addClass(element: string, classname: string) {
+  const el = document.querySelectorAll(element);
+
+  for (let i = 0; i < el.length; i++) {
+    el[i].classList.add(classname);
+  }
+}
+
+function removeClass(element: string, classname: string) {
+  const el = document.querySelectorAll(element);
+
+  for (let i = 0; i < el.length; i++) {
+    el[i].classList.remove(classname);
+  }
+}
+
 const scriptImportedFromExternalRepository = () => {
-  // ==UserScript==
-  // @name         Distractions
-  // @namespace    https://github.com/alphagov/accessibility-personas
-  // @version      1.0.0
-  // @license      ISC
-  // @author       Metamatrix AB [https://github.com/Metamatrix/web-disability-simulator] and Crown Copyright (Government Digital Service)
-  // @description  Clutter the screen with various distractions to simulate finding it hard to concentrate; has to be used together with distractions.user.css to work
-  // @homepageURL  https://alphagov.github.io/accessibility-personas/
-  // @include      *
-  // @grant        none
-  // @nocompat     Chrome
-  // ==/UserScript==
-
-  //dom elements to apply animations on
-  const h2 = "h2";
-  const p = "p";
-  const img = "img";
-
-  //dom elements to be created
-  const imgEl_0 = ".wds-img-element";
-  const textEl_0 = ".wds-text-element-0";
-  const textEl_1 = ".wds-text-element-1";
-  const textEl_2 = ".wds-text-element-2";
-  const textEl_3 = ".wds-text-element-3";
-  const textEl_4 = ".wds-text-element-4";
-
-  //classes for css animations
-  const paragraphAnimation = "wds-paragraph-animation";
-  const headingAnimation = "wds-heading-animation";
-  const imgAnimation_0 = "wds-img-animation-0";
-  const imgAnimation_1 = "wds-img-animation-1";
-  const textAnimation_0 = "wds-text-animation-0";
-  const textAnimation_1 = "wds-text-animation-1";
-  const textAnimation_2 = "wds-text-animation-2";
-  const textAnimation_3 = "wds-text-animation-3";
-  const textAnimation_4 = "wds-text-animation-4";
-
-  (function () {
-    "use strict";
-
-    function createElement(
-      element: string,
-      classname: string,
-      textNode?: string
-    ) {
-      const el = document.createElement(element);
-      el.setAttribute("class", classname);
-      document.body.appendChild(el);
-      if (textNode) {
-        el.appendChild(document.createTextNode(textNode));
-      }
+  function createElement(
+    element: string,
+    classname: string,
+    textNode?: string
+  ) {
+    const el = document.createElement(element);
+    el.setAttribute("class", classname);
+    document.body.appendChild(el);
+    if (textNode) {
+      el.appendChild(document.createTextNode(textNode));
     }
+  }
 
-    createElement("div", "wds-img-element");
+  createElement("div", "wds-img-element");
 
-    function createTextElements(text: string, index: number) {
-      createElement("span", `wds-text-element-${index}`, text);
-    }
+  function createTextElements(text: string, index: number) {
+    createElement("span", `wds-text-element-${index}`, text);
+  }
 
-    const texts = [
-      "Did I eat lunch?",
-      "I have to get back to work soon...",
-      "The ventilation sounds a lot today. bzzzzzz",
-      "Should I answer that text message?",
-      "Must concentrate, must concentrate, must concentrate",
-    ];
+  const texts = [
+    "Did I eat lunch?",
+    "I have to get back to work soon...",
+    "The ventilation sounds a lot today. bzzzzzz",
+    "Should I answer that text message?",
+    "Must concentrate, must concentrate, must concentrate",
+  ];
 
-    texts.forEach(createTextElements);
+  texts.forEach(createTextElements);
 
-    function addClass(element: string, classname: string) {
-      const el = document.querySelectorAll(element);
+  //add and remove animation classes, then loop
+  function launchAnimations() {
+    TIMEOUTS.setTimeout(() => {
+      addClass(p, paragraphAnimation);
+      addClass(imgEl_0, imgAnimation_0);
+      addClass(img, imgAnimation_1);
+      addClass(h2, headingAnimation);
+    }, 500);
 
-      for (let i = 0; i < el.length; i++) {
-        el[i].classList.toggle(classname);
-      }
-    }
+    TIMEOUTS.setTimeout(() => {
+      removeClass(imgEl_0, imgAnimation_0);
+      addClass(textEl_0, textAnimation_0);
+    }, 5000);
 
-    function removeClass(element: string, classname: string) {
-      const el = document.querySelectorAll(element);
+    TIMEOUTS.setTimeout(() => {
+      removeClass(textEl_0, textAnimation_0);
+      addClass(textEl_1, textAnimation_1);
+    }, 12000);
 
-      for (let i = 0; i < el.length; i++) {
-        el[i].classList.remove(classname);
-      }
-    }
+    TIMEOUTS.setTimeout(() => {
+      removeClass(textEl_1, textAnimation_1);
+      addClass(textEl_2, textAnimation_2);
+    }, 20000);
 
-    //add and remove animation classes, then loop
+    TIMEOUTS.setTimeout(() => {
+      removeClass(textEl_2, textAnimation_2);
+      addClass(textEl_3, textAnimation_3);
+    }, 26000);
 
-    function loopAnimations() {
-      setTimeout(() => {
-        addClass(p, paragraphAnimation);
-        addClass(imgEl_0, imgAnimation_0);
-        addClass(img, imgAnimation_1);
-        addClass(h2, headingAnimation);
-      }, 500);
+    TIMEOUTS.setTimeout(() => {
+      removeClass(textEl_3, textAnimation_3);
+      addClass(textEl_4, textAnimation_4);
+    }, 32000);
 
-      setTimeout(() => {
-        removeClass(imgEl_0, imgAnimation_0);
-        addClass(textEl_0, textAnimation_0);
-      }, 5000);
+    TIMEOUTS.setTimeout(() => {
+      removeClass(textEl_4, textAnimation_4);
+      TIMEOUTS.clearAllTimeouts();
+    }, 32000);
+  }
 
-      setTimeout(() => {
-        removeClass(textEl_0, textAnimation_0);
-        addClass(textEl_1, textAnimation_1);
-      }, 12000);
+  launchAnimations();
+  distractionIntervale = setInterval(launchAnimations, 32000);
+};
 
-      setTimeout(() => {
-        removeClass(textEl_1, textAnimation_1);
-        addClass(textEl_2, textAnimation_2);
-      }, 20000);
-
-      setTimeout(() => {
-        removeClass(textEl_2, textAnimation_2);
-        addClass(textEl_3, textAnimation_3);
-      }, 26000);
-
-      setTimeout(() => {
-        removeClass(textEl_3, textAnimation_3);
-        addClass(textEl_4, textAnimation_4);
-      }, 32000);
-
-      setTimeout(() => {
-        removeClass(textEl_4, textAnimation_4);
-        removeClass(p, paragraphAnimation);
-        removeClass(img, imgAnimation_1);
-        removeClass(h2, headingAnimation);
-        loopAnimations();
-      }, 38000);
-    }
-    loopAnimations();
-  })();
+export const removeDistractions = () => {
+  clearInterval(distractionIntervale);
+  TIMEOUTS.clearAllTimeouts();
+  removeClass(p, paragraphAnimation);
+  removeClass(img, imgAnimation_1);
+  removeClass(h2, headingAnimation);
+  removeClass(imgEl_0, imgAnimation_0);
+  removeClass(textEl_0, textAnimation_0);
+  removeClass(textEl_1, textAnimation_1);
+  removeClass(textEl_2, textAnimation_2);
+  removeClass(textEl_3, textAnimation_3);
+  removeClass(textEl_4, textAnimation_4);
 };


### PR DESCRIPTION
## What is this pull request doing ?

Use an interval for the loop to add distractions, in order to start the distractions on the page and end it when we change of page.

## Screenshot

<!-- Well, title says it all -->
<!-- If we update something maybe a before and after screen -->

## How is it done ?

Use an interval to launch the loop and save the timeouts for the animations into an array to be able to stop them when we stop the distractions.

## How to test ?

Go the page https://deploy-preview-46--a11yinyerface.netlify.app/fruits-distractions, check that the animations work, and switch of page to be sure the animations stop
