### PR TITLE
add ellipsis on help cards

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -41,7 +41,8 @@
         "body": "Cette page peut vous donner une idée du vécu d'une personne atteinte de dyslexie. La dyslexie est un trouble de la lecture qui touche entre 2.5% et 16% de la population. Si vous voulez faciliter la navigation pour vos utilisateurs, créer des composants très espacés, en faisant attention à la typographie que vous utilisez"
       }
     },
-    "ellipsis-reduce": "Reduce"
+    "ellipsis-reduce": "Reduce",
+    "ellipsis-expand": "Expand"
   },
   "product-category": {
     "fruit": "Fruit",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -40,7 +40,8 @@
         "title": "Dyslexie",
         "body": "Cette page peut vous donner une idée du vécu d'une personne atteinte de dyslexie. La dyslexie est un trouble de la lecture qui touche entre 2.5% et 16% de la population. Si vous voulez faciliter la navigation pour vos utilisateurs, créer des composants très espacés, en faisant attention à la typographie que vous utilisez"
       }
-    }
+    },
+    "ellipsis-reduce": "Reduce"
   },
   "product-category": {
     "fruit": "Fruit",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -40,7 +40,8 @@
         "title": "Dyslexie",
         "body": "Cette page peut vous donner une idée du vécu d'une personne atteinte de dyslexie. La dyslexie est un trouble de la lecture qui touche entre 2.5% et 16% de la population.Si vous voulez faciliter la navigation pour vos utilisateurs, créer des composants très espacés, en faisant attention à la typographie que vous utilisez."
       }
-    }
+    },
+    "ellipsis-reduce": "Réduire"
   },
   "product-category": {
     "fruit": "Fruit",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -41,7 +41,8 @@
         "body": "Cette page peut vous donner une idée du vécu d'une personne atteinte de dyslexie. La dyslexie est un trouble de la lecture qui touche entre 2.5% et 16% de la population.Si vous voulez faciliter la navigation pour vos utilisateurs, créer des composants très espacés, en faisant attention à la typographie que vous utilisez."
       }
     },
-    "ellipsis-reduce": "Réduire"
+    "ellipsis-reduce": "Voir moins",
+    "ellipsis-expand": "Voir plus"
   },
   "product-category": {
     "fruit": "Fruit",

--- a/src/components/ui/Cards/HelpCard/HelpCard.tsx
+++ b/src/components/ui/Cards/HelpCard/HelpCard.tsx
@@ -6,7 +6,7 @@ interface IHelpCard {
   title: string;
   body: string;
   width?: string;
-  withEllipsis?: boolean;
+  withEllipsis: boolean;
 }
 
 interface IHelpCardsGroup {
@@ -14,18 +14,14 @@ interface IHelpCardsGroup {
   disability: string;
 }
 
-const HelpCard = ({ title, body, width, withEllipsis }: IHelpCard) => {
+const HelpCard = ({ title, body, width, withEllipsis = false }: IHelpCard) => {
   const { t } = useTranslation();
 
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(!withEllipsis);
   const paperRef = useRef<HTMLDivElement>(null);
 
   const handleExpansionChange = () => {
     setExpanded(!expanded);
-    if (!expanded && paperRef.current) {
-      // Scroll to the top when expanding
-      paperRef.current.scrollTo({ top: 0, behavior: "smooth" });
-    }
   };
 
   return (
@@ -47,7 +43,6 @@ const HelpCard = ({ title, body, width, withEllipsis }: IHelpCard) => {
         style={{
           height: expanded ? "auto" : "100px",
           overflow: "hidden",
-          position: "relative",
         }}
         ref={paperRef}
       >
@@ -62,11 +57,17 @@ const HelpCard = ({ title, body, width, withEllipsis }: IHelpCard) => {
         <Typography>{body}</Typography>
       </div>
       {withEllipsis && (
-        <Button onClick={handleExpansionChange}>
-          <Typography sx={{ fontWeight: "bold", color: "black" }}>
-            {expanded ? t("help-cards.ellipsis-reduce") : "..."}
-          </Typography>
-        </Button>
+        <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+          <Button onClick={handleExpansionChange} sx={{ padding: 0 }}>
+            <Typography
+              sx={{ fontWeight: "bold", color: "black", fontSize: "0.8em" }}
+            >
+              {expanded
+                ? t("help-cards.ellipsis-reduce")
+                : t("help-cards.ellipsis-expand")}
+            </Typography>
+          </Button>
+        </Box>
       )}
     </Paper>
   );

--- a/src/components/ui/Cards/HelpCard/HelpCard.tsx
+++ b/src/components/ui/Cards/HelpCard/HelpCard.tsx
@@ -1,10 +1,12 @@
-import { Box, Paper, Typography } from "@mui/material";
+import { Box, Button, Paper, Typography } from "@mui/material";
 import { useTranslation } from "next-i18next";
+import { useRef, useState } from "react";
 
 interface IHelpCard {
   title: string;
   body: string;
   width?: string;
+  withEllipsis?: boolean;
 }
 
 interface IHelpCardsGroup {
@@ -12,7 +14,20 @@ interface IHelpCardsGroup {
   disability: string;
 }
 
-const HelpCard: React.FC<IHelpCard> = ({ title, body, width }: IHelpCard) => {
+const HelpCard = ({ title, body, width, withEllipsis }: IHelpCard) => {
+  const { t } = useTranslation();
+
+  const [expanded, setExpanded] = useState(false);
+  const paperRef = useRef<HTMLDivElement>(null);
+
+  const handleExpansionChange = () => {
+    setExpanded(!expanded);
+    if (!expanded && paperRef.current) {
+      // Scroll to the top when expanding
+      paperRef.current.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
+
   return (
     <Paper
       sx={{
@@ -28,15 +43,31 @@ const HelpCard: React.FC<IHelpCard> = ({ title, body, width }: IHelpCard) => {
         marginLeft: "16px",
       }}
     >
-      <Typography
-        sx={{
-          fontSize: "1.2em",
-          fontWeight: "bold",
+      <div
+        style={{
+          height: expanded ? "auto" : "100px",
+          overflow: "hidden",
+          position: "relative",
         }}
+        ref={paperRef}
       >
-        {title}
-      </Typography>
-      <Typography>{body}</Typography>
+        <Typography
+          sx={{
+            fontSize: "1.2em",
+            fontWeight: "bold",
+          }}
+        >
+          {title}
+        </Typography>
+        <Typography>{body}</Typography>
+      </div>
+      {withEllipsis && (
+        <Button onClick={handleExpansionChange}>
+          <Typography sx={{ fontWeight: "bold", color: "black" }}>
+            {expanded ? t("help-cards.ellipsis-reduce") : "..."}
+          </Typography>
+        </Button>
+      )}
     </Paper>
   );
 };
@@ -59,12 +90,14 @@ const HelpCardsGroup: React.FC<IHelpCardsGroup> = ({
           title={t("help-cards.shopping-list.title")}
           body={t("help-cards.shopping-list.body")}
           width="300px"
+          withEllipsis={false}
         />
       ) : null}
       <HelpCard
         title={t("help-cards.disabilities." + disability + ".title")}
-        body={t(t("help-cards.disabilities." + disability + ".body"))}
+        body={t("help-cards.disabilities." + disability + ".body")}
         width="800px"
+        withEllipsis={true}
       />
     </Box>
   );


### PR DESCRIPTION
## What is this pull request doing ?
On rajoute un ellispsis sur les cartes d'info
https://github.com/theodo/a11yinyerface/issues/87

<!-- The linked ticket and short description -->

## Screenshot

<!-- Well, title says it all -->
<!-- If we update something maybe a before and after screen -->
<img width="1395" alt="image" src="https://github.com/theodo/a11yinyerface/assets/73390978/e3022aaa-8ff0-4a5d-8549-d5472361563c">
<img width="1395" alt="image" src="https://github.com/theodo/a11yinyerface/assets/73390978/3f8ed7aa-0f6d-4ef6-bb29-e32dfed032d8">



## How is it done ?

<!-- Strategic choice, something we want to share, ... Can be empty-->

## How to test ?

<!-- How the reviewer can see your updates ? -->
<!-- Most of the time link to the page, but can be to ask to update something in the code to test a feature that is not used yet -->
